### PR TITLE
Fix nel response.php per il TestEnv

### DIFF
--- a/examples/response.php
+++ b/examples/response.php
@@ -13,6 +13,7 @@ if (empty($_GET["b"])) {
 $gestpay = new GestPayCryptWS();
 $gestpay->setShopLogin($_GET["a"]);
 $gestpay->setEncryptedString($_GET["b"]);
+$gestpay->setTestEnv(true);
 
 if (!$gestpay->decrypt()) {
     throw new Exception(


### PR DESCRIPTION
Nel request.php viene fatto il set esplicito dell'ambiente test e viene utilizzato quindi l'url del WS di test per ottenere la stringa che si invia a BancaSella.

Nel response.php manca il set della modalità test e quindi la libreria prova a fare il decode della stringa con l'url di produzione e non corrispondendo sembra che ci siano problemi nel decode lato WS.

Sono alle prime esperienze con PHP e mi ci è voluto un po a verificare tutto l'iter della comunicazione e capire dove risiedeva il problema.
E penso che sia una esperienza comune a tutti quelli che provano a scaricare la libreria e vedono infrante le speranze di veder funzionare il codice di esempio al primo colpo.

In ogni caso grazie di cuore per la condivisione, sono state di grande aiuto per integrare il pagamento sul sito che stò preparando.

Un saluto,
Sandro
